### PR TITLE
Publish subscription-created and subscription-removed to wiretap on subscribe/unsubscribe

### DIFF
--- a/src/main/Constants.js
+++ b/src/main/Constants.js
@@ -1,6 +1,7 @@
 var DEFAULT_EXCHANGE = "/",
     DEFAULT_PRIORITY = 50,
     DEFAULT_DISPOSEAFTER = 0,
+    SYSTEM_EXCHANGE = "postal",
     NO_OP = function() { },
     parsePublishArgs = function(args) {
         var parsed = { envelope: { } }, env;

--- a/src/main/LocalBus.js
+++ b/src/main/LocalBus.js
@@ -42,11 +42,6 @@ var localBus = {
             }
             if(!found) {
                 this.subscriptions[subDef.exchange][subDef.topic].unshift(subDef);
-                this.notifyTaps({
-                        event: "subscription-created",
-                        exchange: subDef.exchange,
-                        topic: subDef.topic
-                    }, {});
             }
         }
 
@@ -63,11 +58,6 @@ var localBus = {
         if(this.subscriptions[config.exchange][config.topic]) {
             var len = this.subscriptions[config.exchange][config.topic].length,
                 idx = 0;
-            this.notifyTaps({
-                event: "subscription-removed",
-                exchange: config.exchange,
-                topic: config.topic
-            }, {});
             for ( ; idx < len; idx++ ) {
                 if (this.subscriptions[config.exchange][config.topic][idx] === config) {
                     this.subscriptions[config.exchange][config.topic].splice( idx, 1 );

--- a/src/main/SubscriptionDefinition.js
+++ b/src/main/SubscriptionDefinition.js
@@ -7,11 +7,24 @@ var SubscriptionDefinition = function(exchange, topic, callback) {
     this.maxCalls = DEFAULT_DISPOSEAFTER;
     this.onHandled = NO_OP;
     this.context = null;
+
+    postal.publish(SYSTEM_EXCHANGE, "subscription.created",
+        {
+            event: "subscription.created",
+            exchange: exchange,
+            topic: topic
+        });
 };
 
 SubscriptionDefinition.prototype = {
     unsubscribe: function() {
         postal.configuration.bus.unsubscribe(this);
+        postal.publish(SYSTEM_EXCHANGE, "subscription.removed",
+            {
+                event: "subscription.removed",
+                exchange: this.exchange,
+                topic: this.topic
+            });
     },
 
     defer: function() {


### PR DESCRIPTION
Complete with new tests. No tests broken.

This would allow other projects to detect a subscribers interest in a specific topic and thus do selective publishing or even cause up-stream changes.
