### PR TITLE
Fixed issue with linkChannels that would prevent multiple output topics ...

### DIFF
--- a/spec/Postal.spec.js
+++ b/spec/Postal.spec.js
@@ -778,6 +778,33 @@ QUnit.specify( "postal.js", function () {
 				} );
 			} );
 		} );
+		describe( "When binding channel - one source to multiple destinations", function () {
+			var destData = [],
+				destEnv = [],
+				callback = function ( data, env ) {
+					destData.push( data );
+					destEnv.push( env );
+				};
+
+			before( function () {
+				linkages = postal.linkChannels(
+					{ channel : "sourceChannel", topic: "Oh.Hai.There" }, 
+					[
+						{ channel : "destinationChannel", topic: "NewTopic.Oh.Hai" },
+						{ channel : "destinationChannel", topic: "NewTopic.Oh.Hai.There" }
+					]);
+				postal.subscribe( { channel : "destinationChannel", topic : "NewTopic.Oh.Hai", callback : callback} );
+				postal.subscribe( { channel : "destinationChannel", topic : "NewTopic.Oh.Hai.There", callback : callback } );
+				postal.publish( "sourceChannel", "Oh.Hai.There", { data : "I'm in yer bus, linkin' to yer subscriptionz..."} );
+			} );
+			after( function () {
+				postal.utils.reset();
+			} );
+			it( "linked subscriptions should each have been called once", function () {
+				assert( destData.length ).equals( 2 );
+				assert( destEnv.length ).equals( 2 );
+			} );
+		});
 		describe( "When calling postal.utils.reset", function () {
 			var resolver;
 			before( function () {

--- a/src/Api.js
+++ b/src/Api.js
@@ -107,7 +107,7 @@ var postal = {
 						channel : source.channel || DEFAULT_CHANNEL,
 						topic : source.topic || "#",
 						callback : function ( data, env ) {
-							var newEnv = env;
+							var newEnv = _.clone( env );
 							newEnv.topic = _.isFunction( destination.topic ) ? destination.topic( env.topic ) : destination.topic || env.topic;
 							newEnv.channel = destChannel;
 							newEnv.data = data;


### PR DESCRIPTION
...from publishing.

The issue was the envelope was being modified, but not cloned. Due to this, once it was modified, subsequent topics wouldn't be published correctly.
