### PR TITLE
Added anvil.jshint to build.json and fixed mixed tabs/spaces in api.js

### DIFF
--- a/build.json
+++ b/build.json
@@ -1,20 +1,23 @@
 {
 	"anvil.uglify" : {
-        "exclude": ["./node/postal.js", "./node/classic-resolver.js"]
-    },
+		"exclude": ["./node/postal.js", "./node/classic-resolver.js"]
+	},
 	"anvil.http": {
 		"paths": {
-        	"/": "./"
-        },
-        "port" : 8080
-    },
-    "output": {
-        "full": "lib",
-        "partial": {
-        	"/standard/postal.*": "./example/standard/js",
-        	"/amd/postal.*": [ "./example/amd/js/libs/postal", "./example/node/client/js/lib" ],
-        	"/node/postal.js": "./example/node/messaging"
-        }
-    },
-    "dependencies": [ "anvil.http", "anvil.uglify" ]
+			"/": "./"
+		},
+		"port" : 8080
+	},
+	"anvil.jshint" : {
+		"all": true
+	},
+	"output": {
+		"full": "lib",
+		"partial": {
+			"/standard/postal.*": "./example/standard/js",
+			"/amd/postal.*": [ "./example/amd/js/libs/postal", "./example/node/client/js/lib" ],
+			"/node/postal.js": "./example/node/messaging"
+		}
+	},
+	"dependencies": [ "anvil.http", "anvil.uglify" ]
 }

--- a/src/Api.js
+++ b/src/Api.js
@@ -136,7 +136,7 @@ var postal = {
 				}
 			}
 			if ( postal.configuration.bus.subscriptions[ channel ] &&
-			     postal.configuration.bus.subscriptions[ channel ].hasOwnProperty( tpc ) ) {
+				postal.configuration.bus.subscriptions[ channel ].hasOwnProperty( tpc ) ) {
 				result = postal.configuration.bus.subscriptions[ channel ][ tpc ];
 			}
 			return result;


### PR DESCRIPTION
In addition I also made the build.json file use tabs instead of mixed tabs/spaces. anvil.jshint didn't catch that since it only checks *.js files, but I noticed it. You can find out  more of the anvil.jshint plugin and it's options from it's repo https://github.com/elijahmanor/anvil.jshint If you find any issues with it or recommendations please let me know ;)
