### PR TITLE
Removed unused reference to "document"

### DIFF
--- a/src/browser/postal.js
+++ b/src/browser/postal.js
@@ -1,14 +1,14 @@
-(function ( root, doc, factory ) {
+(function ( root, factory ) {
 	if ( typeof define === "function" && define.amd ) {
 		// AMD. Register as an anonymous module.
 		define( ["underscore"], function ( _ ) {
-			return factory( _, root, doc );
+			return factory( _, root );
 		} );
 	} else {
 		// Browser globals
-		factory( root._, root, doc );
+		factory( root._, root );
 	}
-}( this, document, function ( _, global, document, undefined ) {
+}( this, function ( _, global, undefined ) {
 
 	//import("../Constants.js");
 	//import("../ConsecutiveDistinctPredicate.js");


### PR DESCRIPTION
The `document` global is not used in postal afaic. You could still access it through `global.window`.

I understand this is a browser version of postal, but it actually broke my r.js optimized build, since postal tries to access this global property on boot (while in Node env).
