### PR TITLE
Errors in subscribers shouldn't break message propagation

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -27,7 +27,7 @@
     ],
     "dependencies": {
         "lodash": "~2.4.1",
-        "conduitjs": "~0.3.0"
+        "conduitjs": "~0.3.2"
     },
     "devDependencies": {
         "jquery": "~1.10.2",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     },
     "dependencies": {
         "lodash": "~2.4.1",
-        "conduitjs": "~0.3.0"
+        "conduitjs": "~0.3.2"
     },
     "bundleDependencies": [
         "lodash"

--- a/src/SubscriptionDefinition.js
+++ b/src/SubscriptionDefinition.js
@@ -7,17 +7,6 @@ var SubscriptionDefinition = function ( channel, topic, callback ) {
     if(topic.length === 0) {
         throw new Error("Topics cannot be empty");
     }
-
-    var report = function() {};
-    if( console ) {
-        if( console.warn ) {
-            report = console.warn;
-        } else {
-            report = console.log;
-        }
-    }
-
-    this.errorHandler = report;
     this.channel = channel;
     this.topic = topic;
     this.subscribe(callback);


### PR DESCRIPTION
Add try catch around subscription callback invocations. Add support for subscription callback error handlers. Provide a default error handler that will report subscription exceptions as console.warning or console.log when available.

This change doesn't _appear_ to have a significant impact on performance but I haven't really tested performance differences properly :smile:
### An demo appears!

``` javascript
    channel
        .subscribe( '#', function() { 
            throw new Error( 'EVERYBODY PANIC!' );
        } )
        .catch( function( err, args ) {
            // args contains the 'envelope' so that your handler has access to the channel, topic, and data
        } );
```
