### PR TITLE
Changes SubscriptionDefinition.logError to deal with IE8

### DIFF
--- a/src/SubscriptionDefinition.js
+++ b/src/SubscriptionDefinition.js
@@ -185,8 +185,7 @@ SubscriptionDefinition.prototype = {
             } else {
                 report = console.log;
             }
-            this.
-            catch (report);
+            this['catch'](report);
         }
         return this;
     },


### PR DESCRIPTION
IE8 does not allow the keyword 'catch' to be used to call
a method so this change uses square brackets notation to get
round this.
