### PR TITLE
component: Fix lodash dependency

### DIFF
--- a/component.json
+++ b/component.json
@@ -17,7 +17,7 @@
         "envelope"
     ],
     "dependencies": {
-        "component/lodash": "*",
+        "lodash/lodash": "*",
         "ifandelse/ConduitJS": "~0.3.2"
     },
     "scripts": ["lib/postal.min.js", "lib/postal.js"],


### PR DESCRIPTION
This patch fixes the ability to use postal.js with component/duo.  The lodash repository is actually `lodash/lodash`, rather than `component/lodash`.

See duojs/duo#349.
