### PR TITLE
Don't use main field in bower.json for min version

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -22,7 +22,6 @@
         "url": "git://github.com/postaljs/postal.js.git"
     },
     "main": [
-        "lib/postal.min.js",
         "lib/postal.js"
     ],
     "dependencies": {


### PR DESCRIPTION
From doc : "main string or array: The primary acting files necessary to use your package."

This can be a problem when using automatic index file build that use this field.