### PR TITLE
Update lodash v3.

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,7 +85,7 @@
     "node": ">=0.4.0"
   },
   "dependencies": {
-    "lodash": "~2.4.1"
+    "lodash": "~3.1.0"
   },
   "devDependencies": {
     "bower": "~1.2.8",

--- a/src/Api.js
+++ b/src/Api.js
@@ -239,7 +239,7 @@ _.extend( postal, {
 				}
 				if ( topicSubs.length === 0 ) {
 					delete channelSubs[ subDef.topic ];
-					if ( _.isEmpty( channelSubs ) ) {
+					if ( !_.keys( channelSubs ).length ) {
 						delete this.subscriptions[ subDef.channel ];
 					}
 				}

--- a/src/SubscriptionDefinition.js
+++ b/src/SubscriptionDefinition.js
@@ -18,12 +18,12 @@ var ConsecutiveDistinctPredicate = function() {
 	var previous;
 	return function( data ) {
 		var eq = false;
-		if ( _.isString( data ) ) {
+		if ( typeof data == 'string' ) {
 			eq = data === previous;
 			previous = data;
 		} else {
 			eq = _.isEqual( data, previous );
-			previous = _.clone( data );
+			previous = _.extend( {}, data );
 		}
 		return !eq;
 	};
@@ -33,11 +33,7 @@ var DistinctPredicate = function DistinctPredicateFactory() {
 	var previous = [];
 	return function DistinctPredicate( data ) {
 		var isDistinct = !_.any( previous, function( p ) {
-			if ( _.isObject( data ) || _.isArray( data ) ) {
-				return _.isEqual( data, p );
-			} else {
-				return data === p;
-			}
+			return _.isEqual( data, p );
 		} );
 		if ( isDistinct ) {
 			previous.push( data );
@@ -66,7 +62,7 @@ SubscriptionDefinition.prototype = {
 	},
 
 	disposeAfter: function disposeAfter( maxCalls ) {
-		if ( !_.isNumber( maxCalls ) || maxCalls <= 0 ) {
+		if ( typeof maxCalls != 'number' || maxCalls <= 0 ) {
 			throw new Error( "The value provided to disposeAfter (maxCalls) must be a number greater than zero." );
 		}
 		var self = this;
@@ -147,7 +143,7 @@ SubscriptionDefinition.prototype = {
 	},
 
 	constraint: function constraint( predicate ) {
-		if ( !_.isFunction( predicate ) ) {
+		if ( typeof predicate != 'function' ) {
 			throw new Error( "Predicate constraint must be a function" );
 		}
 		this.pipeline.push( function( data, env, next ) {
@@ -161,11 +157,9 @@ SubscriptionDefinition.prototype = {
 	constraints: function constraints( predicates ) {
 		var self = this;
 		/* istanbul ignore else */
-		if ( _.isArray( predicates ) ) {
-			_.each( predicates, function( predicate ) {
-				self.constraint( predicate );
-			} );
-		}
+		_.each( predicates, function( predicate ) {
+			self.constraint( predicate );
+		} );
 		return self;
 	},
 
@@ -175,7 +169,7 @@ SubscriptionDefinition.prototype = {
 	},
 
 	debounce: function debounce( milliseconds, immediate ) {
-		if ( !_.isNumber( milliseconds ) ) {
+		if ( typeof milliseconds != 'number' ) {
 			throw new Error( "Milliseconds must be a number" );
 		}
 		this.pipeline.push(
@@ -190,7 +184,7 @@ SubscriptionDefinition.prototype = {
 	},
 
 	delay: function delay( milliseconds ) {
-		if ( !_.isNumber( milliseconds ) ) {
+		if ( typeof milliseconds != 'number' ) {
 			throw new Error( "Milliseconds must be a number" );
 		}
 		var self = this;
@@ -203,7 +197,7 @@ SubscriptionDefinition.prototype = {
 	},
 
 	throttle: function throttle( milliseconds ) {
-		if ( !_.isNumber( milliseconds ) ) {
+		if ( typeof milliseconds != 'number' ) {
 			throw new Error( "Milliseconds must be a number" );
 		}
 		var fn = function( data, env, next ) {

--- a/src/mindash.js
+++ b/src/mindash.js
@@ -1,0 +1,17 @@
+var createPartialWrapper = require('lodash/internal/createPartialWrapper');
+
+var _ = {
+    after: require('lodash/function/after'),
+    any: require('lodash/internal/arraySome'),
+    bind: function(func, thisArg, arg) {
+      return createPartialWrapper(func, 33, thisArg, [arg]);
+    },
+    debounce: require('lodash/function/debounce'),
+    each: require('lodash/internal/baseEach'),
+    extend: require('lodash/internal/baseAssign'),
+    filter: require('lodash/internal/arrayFilter'),
+    isEqual: require('lodash/lang/isEqual'),
+    keys: require('lodash/object/keys'),
+    map: require('lodash/internal/arrayMap'),
+    throttle: require('lodash/function/throttle')
+};

--- a/src/postal.js
+++ b/src/postal.js
@@ -1,18 +1,20 @@
 /*jshint -W098 */
 (function( root, factory ) {
+	//import("mindash.js");
+
 	/* istanbul ignore if  */
 	if ( typeof define === "function" && define.amd ) {
 		// AMD. Register as an anonymous module.
-		define( [ "lodash" ], function( _ ) {
+		define(function() {
 			return factory( _, root );
 		} );
 	/* istanbul ignore else */
 	} else if ( typeof module === "object" && module.exports ) {
 		// Node, or CommonJS-Like environments
-		module.exports = factory( require( "lodash" ), this );
+		module.exports = factory( _, this );
 	} else {
 		// Browser globals
-		root.postal = factory( root._, root );
+		root.postal = factory( _, root );
 	}
 }( this, function( _, global, undefined ) {
 


### PR DESCRIPTION
Updates lodash to v3 to take advantage of cherry-picking modules for a smaller bundle size.
Using the [bundle-collapser](https://www.npmjs.com/package/bundle-collapser) Browserify plugin, some additional Uglify commands, & [gzip-size](https://www.npmjs.com/package/gzip-size):

```bash
$ browserify test.js -p bundle-collapser/plugin -o bundle.js
$ uglifyjs bundle.js -m -c "comparisons=false,keep_fargs=true,unsafe=true,unsafe_comps=true,warnings=false" -b "ascii_only=true,beautify=false" -o bundle.min.js
```

Also included are results of replacing the Browserify-step with [webpack](https://www.npmjs.com/package/webpack):
```bash
webpack --optimize-dedup --optimize-occurence-order test.js bundle.js
```

For kitchen sink `require('lodash')` of 2.4.1 the size is
```bash
$ gzip-size bundle.min.js # => browserify: 14.96kb; webpack: 13.3kb
```

For cherry-pick `require('lodash/foo/bar')` of 3.1.0 the size is
```bash
$ gzip-size bundle.min.js # => browserify: 6.65kb; webpack: 6.4kb
```