### PR TITLE
fix syntax error on IE8

### DIFF
--- a/lib/postal.js
+++ b/lib/postal.js
@@ -171,8 +171,7 @@
                 } else {
                     report = console.log;
                 }
-                this.
-                catch (report);
+                this.catch (report);
             }
             return this;
         },


### PR DESCRIPTION
@ifandelse it's a minor fix, but I saw a syntax error on IE8. 