### PR TITLE
Use native bind to aid with memory concerns in Node

### DIFF
--- a/src/Api.js
+++ b/src/Api.js
@@ -51,8 +51,8 @@ function getSystemMessage( kind, subDef ) {
 	};
 }
 
-var sysCreatedMessage = _.bind( getSystemMessage, this, "created" );
-var sysRemovedMessage = _.bind( getSystemMessage, this, "removed" );
+var sysCreatedMessage = getSystemMessage.bind( undefined, "created" );
+var sysRemovedMessage = getSystemMessage.bind( undefined, "removed" );
 
 function getPredicate( options, resolver ) {
 	if ( typeof options === "function" ) {

--- a/src/SubscriptionDefinition.js
+++ b/src/SubscriptionDefinition.js
@@ -65,15 +65,12 @@ SubscriptionDefinition.prototype = {
 		if ( typeof maxCalls !== "number" || maxCalls <= 0 ) {
 			throw new Error( "The value provided to disposeAfter (maxCalls) must be a number greater than zero." );
 		}
-		var self = this;
-		var dispose = _.after( maxCalls, _.bind( function() {
-			self.unsubscribe();
-		} ) );
-		self.pipeline.push( function( data, env, next ) {
+		var dispose = _.after( maxCalls, this.unsubscribe.bind( this ) );
+		this.pipeline.push( function( data, env, next ) {
 			next( data, env );
 			dispose();
 		} );
-		return self;
+		return this;
 	},
 
 	distinct: function distinct() {


### PR DESCRIPTION
Based on some memory usage concerns in Node when frequently using `.once`, we found that using the native bind had a great impact on reducing garbage being generated when this is called frequently (many times per second). I did not build the postal lib files in the PR and this does mean that the lib would require an environment with `Function.bind` (would need shim in IE8).