### PR TITLE
Fix vulnerability due to lodash <4.17.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 [![Build Status](https://travis-ci.org/postaljs/postal.js.svg?branch=master)](https://travis-ci.org/postaljs/postal.js)
 
-## Version 2.0.5 ([MIT](http://www.opensource.org/licenses/mit-license))
+## Version 2.0.6 ([MIT](http://www.opensource.org/licenses/mit-license))
 
 > See the [changelog](https://github.com/postaljs/postal.js/blob/master/changelog.md) for information on if the current version of postal has breaking changes compared to any older version(s) you might be using. Version 0.11+ removed the dependency on ConduitJS and significantly improved publishing performance. Version 1.0+ added an optional embedded-and-customized-lodash build.
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,8 @@
 # v2.x
 
+## v2.0.6
+* Update lodash version as per CVE-2019-10744
+
 ## v2.0.5
 * Fixed caching when resolverNoCache is set to true
 * Allowed resolverNoCache config option to be passed to envelope headers

--- a/component.json
+++ b/component.json
@@ -2,7 +2,7 @@
     "name": "postal.js",
     "repo": "postaljs/postal.js",
     "description": "Client-side messaging library",
-    "version": "2.0.5",
+    "version": "2.0.6",
     "keywords": [
         "pub/sub",
         "pub",
@@ -17,7 +17,7 @@
         "envelope"
     ],
     "dependencies": {
-        "component/lodash": "^4.12"
+        "component/lodash": "^4.17.15"
     },
     "scripts": ["lib/postal.min.js", "lib/postal.js"],
     "license": "MIT"

--- a/lib/postal.js
+++ b/lib/postal.js
@@ -1,7 +1,7 @@
 /**
  * postal - Pub/Sub library providing wildcard subscriptions, complex message handling, etc.  Works server and client-side.
  * Author: Jim Cowart (http://ifandelse.com)
- * Version: v2.0.5
+ * Version: v2.0.6
  * Url: http://github.com/postaljs/postal.js
  * License(s): MIT
  */

--- a/lib/postal.lodash.js
+++ b/lib/postal.lodash.js
@@ -1,7 +1,7 @@
 /**
  * postal - Pub/Sub library providing wildcard subscriptions, complex message handling, etc.  Works server and client-side.
  * Author: Jim Cowart (http://ifandelse.com)
- * Version: v2.0.5
+ * Version: v2.0.6
  * Url: http://github.com/postaljs/postal.js
  * License(s): MIT
  */

--- a/lib/postal.lodash.min.js
+++ b/lib/postal.lodash.min.js
@@ -1,7 +1,7 @@
 /**
  * postal - Pub/Sub library providing wildcard subscriptions, complex message handling, etc.  Works server and client-side.
  * Author: Jim Cowart (http://ifandelse.com)
- * Version: v2.0.5
+ * Version: v2.0.6
  * Url: http://github.com/postaljs/postal.js
  * License(s): MIT
  */

--- a/lib/postal.min.js
+++ b/lib/postal.min.js
@@ -1,7 +1,7 @@
 /**
  * postal - Pub/Sub library providing wildcard subscriptions, complex message handling, etc.  Works server and client-side.
  * Author: Jim Cowart (http://ifandelse.com)
- * Version: v2.0.5
+ * Version: v2.0.6
  * Url: http://github.com/postaljs/postal.js
  * License(s): MIT
  */

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "postal",
   "description": "Pub/Sub library providing wildcard subscriptions, complex message handling, etc.  Works server and client-side.",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "homepage": "http://github.com/postaljs/postal.js",
   "repository": {
     "type": "git",
@@ -79,6 +79,10 @@
     {
       "name": "Adria Jimenez",
       "url": "https://github.com/ajimix"
+    },
+    {
+      "name": "Parker Johansen",
+      "url": "https://github.com/auroq"
     }
   ],
   "keywords": [
@@ -105,7 +109,7 @@
     "node": ">=0.4.0"
   },
   "dependencies": {
-    "lodash": "^4.12.0"
+    "lodash": "^4.17.15"
   },
   "devDependencies": {
     "bower": "^1.4.1",


### PR DESCRIPTION
Updated lodash to 4.17.15 to protect against vulnerability in lodash in CVE-2019-10744:

https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2019-10744