### PR TITLE
Update .npmignore to remove extraneous report/ folder

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -14,3 +14,4 @@ component.json
 .npmignore
 classic-resolver*
 bower*
+report/


### PR DESCRIPTION
A report/ folder is getting uploaded to the npm package, but is hidden in the git repo. This should be removed if it truly isn't meant to be uploaded.