### PR TITLE
Unsubscribe leaks subscriptions

### DIFF
--- a/src/Api.js
+++ b/src/Api.js
@@ -226,7 +226,7 @@ _.extend( postal, {
 			subDef.inactive = true;
 			if ( pubInProgress ) {
 				unSubQueue.push( subDef );
-				return;
+				continue;
 			}
 			channelSubs = this.subscriptions[ subDef.channel ];
 			topicSubs = channelSubs && channelSubs[ subDef.topic ];


### PR DESCRIPTION
This only happens when publish is in progress. Unsubscribe goes through passed in subscriptions and adds the first subscription to the unsubscribe queue, but not the rest. Changing the return statement to continue fixes this, since it won't exit the for loop until it goes through all of the subscriptions and adds them to unsubscribe queue.